### PR TITLE
✨ Programmatically determine long_form for en

### DIFF
--- a/lib/ordinalize_full.rb
+++ b/lib/ordinalize_full.rb
@@ -35,7 +35,11 @@ module OrdinalizeFull
 
       value
     else
-      I18n.t("ordinalize_full.n_#{self}", throw: true)
+      begin
+        integer_to_long_form_ordinal
+      rescue ArgumentError
+        I18n.t("ordinalize_full.n_#{self}", throw: true)
+      end
     end
   rescue ArgumentError
     raise NotImplementedError, "Unknown locale #{I18n.locale}"
@@ -82,5 +86,60 @@ private
     end
 
     [self, suffix].join
+  end
+
+
+  # Build the long form of a given number. In this context, it is used for every digit except the last two.
+  # @param number [Integer] - A number to write in long form
+  # @return [String] - The long form of a number
+  def number_to_word(number)
+
+    if number == 0
+      I18n.t("long_form.simple.ones.n_0", throw: true)
+    elsif number < 20
+      I18n.t("long_form.simple.ones.n_#{number}", throw: true)
+    elsif number < 100
+      "#{I18n.t("long_form.simple.tens.n_#{(number / 10)}", throw: true)}#{(number % 10 == 0) ? "" : "-#{I18n.t("long_form.simple.ones.n_#{number % 10}", throw: true)}"}"
+    elsif number < 1000
+      "#{I18n.t("long_form.simple.ones.n_#{number / 100}", throw: true)} #{I18n.t("long_form.simple.hundred", throw: true)}#{(number % 100 == 0) ? "" : " and #{number_to_word(number % 100)}"}"
+    else
+      i = 0
+      meow = number
+      while meow >= 1000
+        meow /= 1000
+        i += 1
+      end
+      the_one_tenth = number % ((10**(3 * i)))
+      "#{number_to_word(meow)} #{(i > 0 ? I18n.t("long_form.simple.larger.n_#{i}", throw: true) : "")}#{(the_one_tenth == 0) ? "" : " #{number_to_word(the_one_tenth)}"}"
+    end
+  end
+
+  # Builds the ordinalized version of a number. Specific to english. Really only the two least significant digits are ordinalized, and the rest are just in long format
+  # @param number [Integer] - A number to ordinalize in long form
+  # @return [String] - The long form of a number as an ordinal
+  def number_to_ordinal_word(number)
+    if number == 0
+      I18n.t("long_form.ordinal.ones.n_0", throw: true)
+    elsif number < 20
+      I18n.t("long_form.ordinal.ones.n_#{number}", throw: true)
+    elsif number < 100 && number % 10 == 0
+      I18n.t("long_form.ordinal.tens.n_#{(number / 10)}", throw: true)
+    elsif number < 100
+      "#{number_to_word(number - (number % 10))}-#{I18n.t("long_form.ordinal.ones.n_#{number % 10}", throw: true)}"
+    elsif number >= 100 && number % 100 == 0
+      "#{number_to_word(number - (number % 100))}th"
+    else
+      "#{number_to_word(number - (number % 100))} and #{number_to_ordinal_word((number % 100))}"
+    end
+  end
+
+  # Builds the long form ordinal of an integer
+  # @return [String] - The long form ordinal of an integer (including negative)
+  def integer_to_long_form_ordinal
+    negative = self < 0 ? true : false
+    
+    return "#{I18n.t("long_form.negative", throw: true)} #{number_to_ordinal_word(-self)}" if negative
+
+    number_to_ordinal_word(self)
   end
 end

--- a/lib/ordinalize_full/locales/en.yml
+++ b/lib/ordinalize_full/locales/en.yml
@@ -1,102 +1,72 @@
 en:
-  ordinalize_full:
-    n_1: first
-    n_2: second
-    n_3: third
-    n_4: fourth
-    n_5: fifth
-    n_6: sixth
-    n_7: seventh
-    n_8: eighth
-    n_9: ninth
-    n_10: tenth
-    n_11: eleventh
-    n_12: twelfth
-    n_13: thirteenth
-    n_14: fourteenth
-    n_15: fifteenth
-    n_16: sixteenth
-    n_17: seventeenth
-    n_18: eighteenth
-    n_19: nineteenth
-    n_20: twentieth
-    n_21: twenty first
-    n_22: twenty second
-    n_23: twenty third
-    n_24: twenty fourth
-    n_25: twenty fifth
-    n_26: twenty sixth
-    n_27: twenty seventh
-    n_28: twenty eighth
-    n_29: twenty ninth
-    n_30: thirtieth
-    n_31: thirty first
-    n_32: thirty second
-    n_33: thirty third
-    n_34: thirty fourth
-    n_35: thirty fifth
-    n_36: thirty sixth
-    n_37: thirty seventh
-    n_38: thirty eighth
-    n_39: thirty ninth
-    n_40: fortieth
-    n_41: forty first
-    n_42: forty second
-    n_43: forty third
-    n_44: forty fourth
-    n_45: forty fifth
-    n_46: forty sixth
-    n_47: forty seventh
-    n_48: forty eighth
-    n_49: forty ninth
-    n_50: fiftieth
-    n_51: fifty first
-    n_52: fifty second
-    n_53: fifty third
-    n_54: fifty fourth
-    n_55: fifty fifth
-    n_56: fifty sixth
-    n_57: fifty seventh
-    n_58: fifty eighth
-    n_59: fifty ninth
-    n_60: sixtieth
-    n_61: sixty first
-    n_62: sixty second
-    n_63: sixty third
-    n_64: sixty fourth
-    n_65: sixty fifth
-    n_66: sixty sixth
-    n_67: sixty seventh
-    n_68: sixty eighth
-    n_69: sixty ninth
-    n_70: seventieth
-    n_71: seventy first
-    n_72: seventy second
-    n_73: seventy third
-    n_74: seventy fourth
-    n_75: seventy fifth
-    n_76: seventy sixth
-    n_77: seventy seventh
-    n_78: seventy eighth
-    n_79: seventy ninth
-    n_80: eightieth
-    n_81: eighty first
-    n_82: eighty second
-    n_83: eighty third
-    n_84: eighty fourth
-    n_85: eighty fifth
-    n_86: eighty sixth
-    n_87: eighty seventh
-    n_88: eighty eighth
-    n_89: eighty ninth
-    n_90: ninetieth
-    n_91: ninety first
-    n_92: ninety second
-    n_93: ninety third
-    n_94: ninety fourth
-    n_95: ninety fifth
-    n_96: ninety sixth
-    n_97: ninety seventh
-    n_98: ninety eighth
-    n_99: ninety ninth
-    n_100: one hundredth
+  long_form:
+    negative: Negative
+    simple:
+      ones:
+        n_0: Zero
+        n_1: One
+        n_2: Two
+        n_3: Three
+        n_4: Four
+        n_5: Five
+        n_6: Six
+        n_7: Seven
+        n_8: Eight
+        n_9: Nine
+        n_10: Ten
+        n_11: Eleven
+        n_12: Twelve
+        n_13: Thirteen
+        n_14: Fourteen
+        n_15: Fifteen
+        n_16: Sixteen
+        n_17: Seventeen
+        n_18: Eighteen
+        n_19: Nineteen
+      tens:
+        n_2: Twenty
+        n_3: Thirty
+        n_4: Forty
+        n_5: Fifty
+        n_6: Sixty
+        n_7: Seventy
+        n_8: Eighty
+        n_9: Ninety
+      hundred: Hundred
+      larger:
+        n_0: ""
+        n_1: Thousand
+        n_2: Million
+        n_3: Billion
+        n_4: Trillion
+    ordinal:
+      ones:
+        n_0: Zeroth
+        n_1: First
+        n_2: Second
+        n_3: Third
+        n_4: Fourth
+        n_5: Fifth
+        n_6: Sixth
+        n_7: Seventh
+        n_8: Eighth
+        n_9: Ninth
+        n_10: Tenth
+        n_11: Eleventh
+        n_12: Twelfth
+        n_13: Thirteenth
+        n_14: Fourteenth
+        n_15: Fifteenth
+        n_16: Sixteenth
+        n_17: Seventeenth
+        n_18: Eigthteenth
+        n_19: Nineteenth
+      tens:
+        n_2: Twentieth
+        n_3: Thirtieth
+        n_4: Fortieth
+        n_5: Fiftieth
+        n_6: Sixtieth
+        n_7: Seventieth
+        n_8: Eightieth
+        n_9: Ninetieth

--- a/spec/ordinalize_full_spec.rb
+++ b/spec/ordinalize_full_spec.rb
@@ -7,11 +7,20 @@ describe OrdinalizeFull do
     context "with the default locale (:en)" do
       before { I18n.locale = :en }
 
-      specify { expect(1.ordinalize_in_full).to eq("first") }
-      specify { expect(42.ordinalize_in_full).to eq("forty second") }
+      specify { expect(1.ordinalize_in_full).to eq("First") }
+      specify { expect(42.ordinalize_in_full).to eq("Forty-Second") }
+      specify { expect(2023.ordinalize_in_full).to eq("Two Thousand and Twenty-Third") }
+      specify { expect(2147483647.ordinalize_in_full).to eq("Two Billion One Hundred and Forty-Seven Million Four Hundred and Eighty-Three Thousand Six Hundred and Forty-Seventh") }
 
-      it "raises with unknown numbers" do
-        expect { 101.ordinalize_in_full }.to raise_error(NotImplementedError)
+      it "converts any number" do
+        rand = Random.new
+        10.times do
+          expect { rand(1000000).ordinalize_in_full }.not_to raise_error
+        end
+      end
+
+      it "handles negatives too" do
+        expect(-273.ordinalize_in_full).to eq("Negative Two Hundred and Seventy-Third")
       end
     end
 
@@ -53,7 +62,7 @@ describe OrdinalizeFull do
     context "with the default locale (:en)" do
       before { I18n.locale = :en }
 
-      specify { expect(1.ordinalize(in_full: true)).to eq("first") }
+      specify { expect(1.ordinalize(in_full: true)).to eq("First") }
       specify { expect(1.ordinalize(in_full: false)).to eq("1st") }
     end
 


### PR DESCRIPTION
For EN only (I started adding the other langs, but there are certain nuances that I don't quite get). Programmatically determine the long form ordinalized version of a given number. Should work for any signed integer supported by ruby. I did not test what happens if you try it with numbers larger than whatever MAX_INT would be, but I would assume things would break well before this point if using such numbers in a real system.

I also capitalized the numbers. not sure if that is the best route for it or not.

I dashed the combined numbers like "Twenty-Three" and "Ninety-Nine" since that seems to be the accepted method for long form numbers.

In theory, the work here could also be used to  write both fractions in long form as well since we basically use the ordinalized version of the decimal part (e.g. "1/10" is "One Tenth")
